### PR TITLE
fix missing 'behaviour' for 'tx_youtubevideo_ratio'

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -92,7 +92,10 @@ defined('TYPO3_MODE') || die('Access denied.');
 	            'renderType' => 'selectSingle',
 	            'items'    => array(), /* items set in page TsConfig */
 	            'size'     => 1,
-	            'maxitems' => 1
+	            'maxitems' => 1,
+              'behaviour' => [
+                'allowLanguageSynchronization' => true,
+              ]
 	        )
 	    ),
 	    'tx_youtubevideo_fullscreen' => array (


### PR DESCRIPTION
This causes a `Call to a member function isCustomState()` error in translated youtubevideo elements in BE.