### PR TITLE
Add missing dependency to t3brightside/paginatedprocessors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
   "require": {
       "typo3/cms-core": "^11.5 || ^12.4",
       "typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
-	  "t3brightside/embedassets": "^1.2"
+	  "t3brightside/embedassets": "^1.2",
+	  "t3brightside/paginatedprocessors": "^1.5"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Without that dependency, the class `Brightside\Paginatedprocessors\Processing\DataToPaginatedData` is not found in `YoutubevideoFilesProcessor`.